### PR TITLE
Enable powertools and epel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ LABEL build_date="2021-10-10"
 
 WORKDIR /github/workspace
 
-RUN dnf install -y rpmdevtools dnf-utils spectool dnf-utils && \
+RUN dnf install -y rpmdevtools dnf-utils spectool dnf-utils epel-release dnf-plugins-core && \
+    dnf config-manager --set-enabled powertools && \
     dnf clean all && \
     rm -r -f /var/cache/*
 


### PR DESCRIPTION
Some builds may require packages that are on this repositories, like meson