### PR TITLE
Enable epel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL build_date="2021-10-10"
 
 WORKDIR /github/workspace
 
-RUN yum install -y rpmdevtools yum-utils spectool && \
+RUN yum install -y rpmdevtools yum-utils spectool epel-release && \
     yum clean all && \
     rm -r -f /var/cache/*
 


### PR DESCRIPTION
Some builds may require packages that are on this repositories, like meson